### PR TITLE
#1: Ишьюзатыщу

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,18 @@ services:
       - '3306:3306'
     env_file:
       - .env
+  smtp:
+    container_name: mospan_pro_smtp
+    image: tianon/exim4
+    restart: always
+    networks:
+      mospan:
+    ports:
+      - '25:25'
+    # Чтобы отсылать от имени пользователя Gmail
+    #environment:
+    #  - GMAIL_USER=username@gmail.com
+    #  - GMAIL_PASSWORD=password
 
 volumes:
   db-data:


### PR DESCRIPTION
Решает задачу #1.

Вот простенький SMTP-сервер, с возможностью переадресации на Gmail.

Отправляем почту тупо в локальный сервер по 25-му порту без авторизации.

Пример на PHP:
```php
use PHPMailer\PHPMailer\PHPMailer;

$mail = new PHPMailer(true);
$mail->isSMTP();                  // Используем отправку через SMTP

$mail->Host       = 'localhost';  // Сервер
$mail->SMTPAuth   = false;        // Выключаем авторизацию
$mail->Username   = '';           // Пустой пользователь SMTP
$mail->Password   = '';           // Пустой пароль password
//$mail->SMTPSecure = 'ssl';      // TLS/SSL не используем
$mail->Port       = 25;           // 25-й порт

// Отправитель и получатель
$mail->setFrom('maximal@mospan.pro', 'MaximAL');
$mail->addAddress('mospan@mospan.pro', 'Mospan');

// Заголовок, HTML-текст и обычный текст
$mail->Subject = 'Here is the subject: ' . date('c');
$mail->Body    = 'This is the HTML message body <b>in bold!</b>';
$mail->AltBody = 'This is the body in plain text for non-HTML mail clients';

// Посылаем
$mail->send();

```

В остальных языках аналогично